### PR TITLE
Create package.json to mimic an npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "utility-contracts",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/api3dao/utility-contracts.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/api3dao/utility-contracts/issues"
+  },
+  "homepage": "https://github.com/api3dao/utility-contracts#readme"
+}


### PR DESCRIPTION
This is needed to run `npm install`, which fails to install a package
that has this package as a dependency (using github dependency).